### PR TITLE
✏️ 댓글 관련 API 자잘하게 수정

### DIFF
--- a/src/routes/comments.router.js
+++ b/src/routes/comments.router.js
@@ -74,6 +74,7 @@ router.get("/posts/:postId/comments", async (req, res, next) => {
     const comments = await prisma.comments.findMany({
       where: { postId: +postId },
       select: {
+        commentId: true,
         content: true,
         user: {
           select: {
@@ -86,7 +87,12 @@ router.get("/posts/:postId/comments", async (req, res, next) => {
       orderBy: { createdAt: "asc" },
     });
 
-    return res.status(200).json({ data: comments });
+    comments.forEach((comments) => {
+      comments.nickname = comments.user.nickname;
+      delete comments.user;
+    });
+
+    return res.status(200).json({ success: true, data: comments });
   } catch (err) {
     next(err);
   }
@@ -155,7 +161,7 @@ router.patch(
 
       return res
         .status(201)
-        .json({ message: "댓글 수정사항이 저장되었습니다." });
+        .json({ success: true, message: "댓글 수정사항이 저장되었습니다." });
     } catch (err) {
       next(err);
     }
@@ -214,7 +220,9 @@ router.delete(
         where: { commentId: +commentId },
       });
 
-      return res.status(204).json({ message: "댓글이 삭제되었습니다." });
+      return res
+        .status(200)
+        .json({ success: true, message: "댓글이 삭제되었습니다." });
     } catch (err) {
       next(err);
     }


### PR DESCRIPTION
- 댓글목록 조회 select로 "user": {"nickname": 어쩌구} 로 뜨는거 다시 매핑해줌.
- 댓글 목록 조회 컬럼에 commentId 넣어줌
- 댓글 삭제 API 스테이터스 코드 204말고 200으로 고침
- 댓글 API 전부 res에 message말고 success도 표시해줌(다들 쓰길래 걍 통일)