### PR TITLE
:recycle: post.router위주로 에러처리 추가/수정

### DIFF
--- a/src/routes/posts.router.js
+++ b/src/routes/posts.router.js
@@ -24,7 +24,7 @@ router.post("/posts", authMiddleware, async (req, res, next) => {
       });
     }
     if (
-      category &&
+      !category ||
       !["recommend", "combination_share", "event_info"].includes(category)
     ) {
       return res.status(400).json({

--- a/src/routes/posts.router.js
+++ b/src/routes/posts.router.js
@@ -33,7 +33,10 @@ router.post("/posts", authMiddleware, async (req, res, next) => {
       });
     }
 
-    if (star && (!Number.isInteger(star) || star < 1 || star > 5)) {
+    if (
+      star != undefined &&
+      (!Number.isInteger(star) || star < 1 || star > 5)
+    ) {
       return res.status(400).json({
         success: false,
         message: "별점은 1~5 값 입니다.",
@@ -138,7 +141,10 @@ router.patch("/posts/:postId", authMiddleware, async (req, res, next) => {
       });
     }
 
-    if (star && (!Number.isInteger(star) || star < 1 || star > 5)) {
+    if (
+      star != undefined &&
+      (!Number.isInteger(star) || star < 1 || star > 5)
+    ) {
       return res.status(400).json({
         success: false,
         message: "별점은 1~5 값 입니다.",

--- a/src/routes/posts.router.js
+++ b/src/routes/posts.router.js
@@ -32,12 +32,14 @@ router.post("/posts", authMiddleware, async (req, res, next) => {
         message: "카테고리가 올바르지 않습니다.",
       });
     }
-    if (!Number.isInteger(star) || star < 1 || star > 5) {
+
+    if (star && (!Number.isInteger(star) || star < 1 || star > 5)) {
       return res.status(400).json({
         success: false,
         message: "별점은 1~5 값 입니다.",
       });
     }
+
     const post = await prisma.posts.create({
       data: {
         userId: +userId,
@@ -88,15 +90,15 @@ router.get("/posts/:postId", async (req, res, next) => {
       },
     });
 
-    post.nickname = post.user.nickname;
-    delete post.user;
-
     if (!post) {
       return res.status(404).json({
         success: false,
         message: "게시글이 존재하지 않습니다.",
       });
     }
+
+    post.nickname = post.user.nickname;
+    delete post.user;
 
     return res
       .status(200)
@@ -136,12 +138,13 @@ router.patch("/posts/:postId", authMiddleware, async (req, res, next) => {
       });
     }
 
-    if (!Number.isInteger(star) || star < 1 || star > 5) {
+    if (star && (!Number.isInteger(star) || star < 1 || star > 5)) {
       return res.status(400).json({
         success: false,
         message: "별점은 1~5 값 입니다.",
       });
     }
+
     if (post.userId !== user.userId && user.grade === "USER") {
       return res.status(401).json({
         success: false,
@@ -153,6 +156,8 @@ router.patch("/posts/:postId", authMiddleware, async (req, res, next) => {
       content: content !== "" ? content : post.content,
       imageURL: imageURL !== "" ? imageURL : post.imageURL,
       tag: tag !== "" ? tag : post.tag,
+      category: category !== "" ? category : post.category,
+      star: star !== "" ? star : post.star,
     };
 
     await prisma.posts.update({


### PR DESCRIPTION
- 게시물 상세 조회할때, 에러처리가 있는데도 post를 불러오지 못하면 error핸들러로 넘어가고있었습니다.
에러처리 코드를 사용하기 전으로 당겨줬습니다.

- 게시글 생성, 수정에서 star값 제한 에러처리 조건식안에 넣었습니다. 
에러처리코드 조건식에 if (star != unfefined && (원래 조건식)) => star는 nullish임!

- 게시글 수정할때 category, star 수정사항이 반영되지 않고 있었습니다. updateData에 컬럼 추가해주었습니다.

-게시글 생성할때 카테고리는 필수값이니까 에러 처리 조건식 (!category || !["recommend", "combination_share", "event_info"].includes(category))으로 고쳤습니다.